### PR TITLE
Update README installation guide 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ A stand alone, light-weight web server for building, sharing graphs created in I
 # Usage
 
 - *Install prerequisite*
+    + install mysql : `brew install mysql` or on Ubuntu `apt-get install mysql-server libmysqlclient-dev`
     + install the latest stable IPython-Dashboard: `pip install ipython-dashboard --upgrade`
     + install redis 2.6+ : [install guide](http://redis.io/topics/quickstart)
-    + install mysql : `brew install mysql` or on Ubuntu `apt-get install mysql-server libmysqlclient-dev`
     + install IPython-Dashboard requirements [unneeded sometimes]:
         - `cd ~/your python package path/IPython-Dashboard`
         - `pip install -r requirements.txt`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A stand alone, light-weight web server for building, sharing graphs created in I
 - *Install prerequisite*
     + install the latest stable IPython-Dashboard: `pip install ipython-dashboard --upgrade`
     + install redis 2.6+ : [install guide](http://redis.io/topics/quickstart)
-    + [`option`, if you need run sql]install mysql : `brew install mysql` or `apt-get install mysql`
+    + install mysql : `brew install mysql` or on Ubuntu `apt-get install mysql-server libmysqlclient-dev`
     + install IPython-Dashboard requirements [unneeded sometimes]:
         - `cd ~/your python package path/IPython-Dashboard`
         - `pip install -r requirements.txt`


### PR DESCRIPTION
It appears that mysql and libmysqlclient-dev is needed for installation (Ubuntu 16.04). A little change in the instruction could be helpful for potential new users. 